### PR TITLE
More helpful exceptions when JSON is invalid

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -312,6 +312,11 @@ class Factory
                     }
                 }
             }
+            if(json_last_error()){
+				throw new Exceptions\DatapackageInvalidSourceException(
+					json_last_error_msg().' when loading source: '.json_encode($source)
+				);
+            }
         } else {
             throw new Exceptions\DatapackageInvalidSourceException(
                 'Invalid source: '.json_encode($source)

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -312,10 +312,10 @@ class Factory
                     }
                 }
             }
-            if(json_last_error()){
-				throw new Exceptions\DatapackageInvalidSourceException(
-					json_last_error_msg().' when loading source: '.json_encode($source)
-				);
+            if (json_last_error()) {
+                throw new Exceptions\DatapackageInvalidSourceException(
+                    json_last_error_msg().' when loading source: '.json_encode($source)
+                );
             }
         } else {
             throw new Exceptions\DatapackageInvalidSourceException(

--- a/tests/DatapackageTest.php
+++ b/tests/DatapackageTest.php
@@ -95,6 +95,19 @@ class DatapackageTest extends TestCase
             function () { Package::load('-invalid-'); }
         );
     }
+    
+    public function testJsonInvalidSyntaxShouldFail()
+    {
+        // http://php.net/manual/en/function.json-decode.php
+        // trailing commas are not allowed
+        $bad_json = '{ "bar": "baz", }';
+        json_decode($bad_json); // null
+        $this->assertDatapackageException(
+            'frictionlessdata\\datapackage\\Exceptions\\DatapackageInvalidSourceException',
+            json_last_error_msg().' when loading source: '.json_encode($bad_json),
+            function () use ($bad_json) { Package::load($bad_json); }
+        );
+    }
 
     public function testJsonFileRelativeToBasePath()
     {

--- a/tests/DatapackageTest.php
+++ b/tests/DatapackageTest.php
@@ -95,7 +95,7 @@ class DatapackageTest extends TestCase
             function () { Package::load('-invalid-'); }
         );
     }
-    
+
     public function testJsonInvalidSyntaxShouldFail()
     {
         // http://php.net/manual/en/function.json-decode.php


### PR DESCRIPTION
Hello,

While exploring integration of data package spec in a PHP application I unknowingly fed invalid JSON to `Package::load` (and `Package::validate`). 

Ultimately this falls over here: 

https://github.com/frictionlessdata/datapackage-php/blob/3c3b4126b7aa8b7edd8a66b89bb5ae124ae7b088/src/Validators/DatapackageValidator.php#L27

with a moderately cryptic `__clone method called on non-object`exception.  

The problem is that `json_decode` [will return NULL][phpjson] but not raise an exception if invalid JSON is supplied. I realise that a datapackage.json file `MUST` be valid JSON, but it would be nicer if we got a useful error when it was not.  

## Example

A minimally invalid datapackage.json might be (the final comma is valid in JS, but not in JSON):

```` json
{
  "name" : "a-unique-human-readable-and-url-usable-identifier",
  "resources": [{
    "name": "solar-system",
    "path": "http://example.com/solar-system.csv"
    }],
}
````

So the following fails:

````php
use frictionlessdata\datapackage\Package;
$package = Package::load('{"name":"a-unique-human-readable-and-url-usable-identifier","resources":[{"name":"solar-system","path":"http://example.com/solar-system.csv"}],}');
````

## Possible Fix?

I am afraid I am too new to the datapackage spec to know if this is a problem, or a problem that should be fixed in this PHP implementation (i.e. should this implementation catch invalid JSON, or just let it slide?). 

For contrast, however, in the Python implementation an exception is thrown [at a similar point in the process][pyFailsHere] if the input is not valid JSON. 

As I say, this pull request addresses the immediate problem of providing invalid JSON, but I am unsure if it is desirable (in principle or in practice). 


[pyFailsHere]: https://github.com/frictionlessdata/datapackage-py/blob/53613ed2b6f3ad043bab420ad4edef97397df257/datapackage/package.py#L255

[phpjson]: http://php.net/manual/en/function.json-decode.php

[L27]: https://github.com/frictionlessdata/datapackage-php/blob/3c3b4126b7aa8b7edd8a66b89bb5ae124ae7b088/src/Validators/DatapackageValidator.php#L27

[L314]: https://github.com/frictionlessdata/datapackage-php/blob/3c3b4126b7aa8b7edd8a66b89bb5ae124ae7b088/src/Factory.php#L314