### PR TITLE
Update the save() method to set relative paths for resources. Fixes frictionlessdata#41.

### DIFF
--- a/src/Datapackages/BaseDatapackage.php
+++ b/src/Datapackages/BaseDatapackage.php
@@ -192,7 +192,9 @@ abstract class BaseDatapackage implements \Iterator
         ];
         $ri = 0;
         foreach ($packageCopy as $resource) {
-            if ($resource->isRemote()) continue;
+            if ($resource->isRemote()) {
+                continue;
+            }
 
             $resourceFiles = [];
             $fileNames = $resource->save($base.'resource-'.$ri);

--- a/src/Datapackages/BaseDatapackage.php
+++ b/src/Datapackages/BaseDatapackage.php
@@ -191,7 +191,9 @@ abstract class BaseDatapackage implements \Iterator
             'datapackage.json' => $base.'datapackage.json',
         ];
         $ri = 0;
-        foreach ($packageCopy->resources() as $resource) {
+        foreach ($packageCopy as $resource) {
+            if ($resource->isRemote()) continue;
+
             $resourceFiles = [];
             $fileNames = $resource->save($base.'resource-'.$ri);
             foreach ($fileNames as $fileName) {
@@ -217,6 +219,11 @@ abstract class BaseDatapackage implements \Iterator
         }
     }
 
+    /**
+     * Make a new Datapackage object that is a copy of the current Datapackage. Bypasses validation.
+     * @return $this
+     * @throws DatapackageValidationFailedException
+     */
     protected function copy()
     {
         return new static($this->descriptor, $this->basePath, true);

--- a/src/Resources/BaseResource.php
+++ b/src/Resources/BaseResource.php
@@ -75,6 +75,10 @@ abstract class BaseResource implements \Iterator
         return $rows;
     }
 
+    /**
+     * Loads $this->dataStreams based on $this->path() and $this->data
+     * @return BaseDataStream[]|null
+     */
     public function dataStreams()
     {
         if (is_null($this->dataStreams)) {
@@ -119,6 +123,25 @@ abstract class BaseResource implements \Iterator
         } else {
             return [];
         }
+    }
+
+    /**
+     * If the resource's $path is local (non-http)
+     * @return bool
+     */
+    public function isLocal()
+    {
+        return !$this->isRemote();
+    }
+
+    /**
+     * If the resource's $path is remote (http)
+     * @return bool
+     */
+    public function isRemote()
+    {
+        $path = $this->path();
+        return Utils::isHttpSource(is_array($path) && count($path) > 0 ? $path[0] : $path);
     }
 
     public function data()

--- a/tests/DatapackageTest.php
+++ b/tests/DatapackageTest.php
@@ -476,12 +476,68 @@ class DatapackageTest extends TestCase
         $zip->close();
         unlink($filename);
         $tempdir = $tempdir.DIRECTORY_SEPARATOR;
+
+        //after saving to disk, the paths are updated
+        $expectedDatapackageDescriptor = (object) [
+            'name' => 'my-datapackage-name',
+            'resources' => [
+                (object) [
+                    'name' => 'my-default-resource',
+                    'path' => ["resource-0-data-0", "resource-0-data-1"],
+                ],
+                (object) [
+                    'name' => 'my-renamed-tabular-resource',
+                    'path' => "resource-1.csv",
+                    'profile' => 'tabular-data-resource',
+                    'schema' => (object) [
+                        'fields' => [
+                            (object) ['name' => 'id', 'type' => 'integer'],
+                            (object) ['name' => 'name', 'type' => 'string'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
         $this->assertEquals($expectedDatapackageDescriptor, json_decode(file_get_contents($tempdir.'datapackage.json')));
         $this->assertEquals('foo', file_get_contents($tempdir.'resource-0-data-0'));
         $this->assertEquals("testing 改善\n", file_get_contents($tempdir.'resource-0-data-1'));
         $this->assertEquals("id,name\n1,one\n2,two\n3,three\n", file_get_contents($tempdir.'resource-1.csv'));
         // Clean up
         Utils::removeDir($tempdir);
+    }
+
+    public function testSaveAndLoadZip()
+    {
+        //create example csv
+        file_put_contents('/tmp/example.csv', "name,email\nJohn Doe,john@example.com");
+
+        //create a new datapackage object
+        $package = Package::create(['name' => 'csv-example','profile' => 'tabular-data-package']);
+
+        //add a csv file
+        $package->addResource('example.csv', [
+            "profile" => "tabular-data-resource",
+            "schema" => ["fields" => [["name" => "name", "type" => "string"],["name" => "email", "type" => "string"]]],
+            "path" => '/tmp/example.csv'
+        ]);
+
+        //save the datapackage
+        if (is_file('datapackage.zip')) {
+            unlink('datapackage.zip');
+        }
+        $package->save("datapackage.zip");
+
+        //delete example csv
+        unlink('/tmp/example.csv');
+
+        //load the new package
+        $package2 = Package::load('datapackage.zip');
+
+        //assert you get expected content back out
+        $this->assertEquals([['name' => 'John Doe', 'email' => 'john@example.com']], $package2->resource('example.csv')->read());
+
+        unlink('datapackage.zip');
     }
 
     public function testLoadDatapackageZip()
@@ -626,10 +682,10 @@ class DatapackageTest extends TestCase
                         'CommitteeTypeDesc' => 'ועדה  משותפת',
                         'Email' => null,
                         'StartDate' => Carbon::__set_state(array(
-                                'date' => '2004-08-12 00:00:00.000000',
-                                'timezone_type' => 3,
-                                'timezone' => 'UTC',
-                            )),
+                            'date' => '2004-08-12 00:00:00.000000',
+                            'timezone_type' => 3,
+                            'timezone' => 'UTC',
+                        )),
                         'FinishDate' => null,
                         'AdditionalTypeID' => null,
                         'AdditionalTypeDesc' => null,
@@ -637,10 +693,10 @@ class DatapackageTest extends TestCase
                         'CommitteeParentName' => null,
                         'IsCurrent' => true,
                         'LastUpdatedDate' => Carbon::__set_state(array(
-                                'date' => '2015-03-20 12:02:57.000000',
-                                'timezone_type' => 3,
-                                'timezone' => 'UTC',
-                            )),
+                            'date' => '2015-03-20 12:02:57.000000',
+                            'timezone_type' => 3,
+                            'timezone' => 'UTC',
+                        )),
                     ), $row);
                 }
                 ++$rowNum;

--- a/tests/Mocks/MockDefaultResource.php
+++ b/tests/Mocks/MockDefaultResource.php
@@ -41,4 +41,17 @@ class MockDefaultResource extends DefaultResource
     {
         return MockResourceValidator::validate($this->descriptor(), $this->basePath);
     }
+
+
+    /**
+     * @inheritDoc
+     * @return bool
+     */
+    public function isRemote()
+    {
+        $path = $this->path();
+        $path_to_check = is_array($path) && count($path) > 0 ? $path[0] : $path;
+        return strpos($path_to_check, 'mock-http://') === 0 || parent::isRemote();
+    }
+
 }


### PR DESCRIPTION
# Overview

Update the save() method to set relative paths for resources. Clones the current package so the path changes only apply to the outputted package, which is what they do in the datapackage-js library (https://github.com/frictionlessdata/datapackage-js/blob/master/src/package.js#L266) Fixes #41.

This is only the second time I've ever submitted a pull request so if there's anything I'm doing wrong please let me know.

---

Please preserve this line to notify @DiegoPino (lead of this repository)
