### PR TITLE
ISSUE-53: update ci.yml to act on renamed main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}


### PR DESCRIPTION
# Overview

Updates GitHub CI action to act on renamed primary branch: `main`